### PR TITLE
Update GitHub Action to trigger deployments only for Terraform files

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,9 +1,23 @@
 name: Terraform
 
 on:
-  pull_request:
-    branches:
-      - main
+    pull_request:
+      branches:
+        - main
+      paths:
+        - 'terraform-modules/**'    # Only trigger when files in the terraform directory -
+        - 'dev/**'                  # and dev directory -
+        - 'prod/**'                 # and prod directory are changed
+        - '!README.md'      # Ignore changes to README.md
+  
+    push:
+      branches:
+        - main
+      paths:
+        - 'terraform-modules/**'    # Only trigger when files in the terraform directory -
+        - 'dev/**'                  # and dev directory -
+        - 'prod/**'                 # and prod directory are changed
+        - '!README.md'      # Ignore changes to README.md
 
 jobs:
   terraform:


### PR DESCRIPTION
This PR modifies the GitHub Actions workflow to ensure that deployments are only triggered when changes are made to Terraform files within the terraform-modules, dev and prod directories. It prevents unnecessary deployments when modifying non-infrastructure files, such as README.md. This helps optimize the workflow and reduce unnecessary Terraform runs.

Key Changes:

	•	Adjusted paths in the GitHub Action to watch only terraform-modules/**, dev/** and prod/** for triggering deployments.
	•	Excluded README.md from triggering deployment actions.